### PR TITLE
Feature [#2302] - Multiple user quest entries

### DIFF
--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -144,19 +144,11 @@ LibQuest {
             "INVALID_TOKEN_BALANCE_ALLOWANCE"
         );
         uint256 _userQuestEntryCount = userQuestEntryCount[user][id];
-        // Previous user quest entry must be NOT_STARTED if userQuestEntryCount == 0
-        if (_userQuestEntryCount == 0)
-            require(
-                userQuestEntries[user][id][_userQuestEntryCount].status == uint8(QuestEntryStatus.NOT_STARTED),
-                "INVALID_PREVIOUS_QUEST_ENTRY_STATUS"
-            );
-        else
-        // Previous user quest entry should be COMPLETED, FAILED or CANCELLED if userQuestEntryCount > 0
-            require(
-                userQuestEntries[user][id][_userQuestEntryCount].status >= uint8(QuestEntryStatus.SUCCESS) &&
-                userQuestEntries[user][id][_userQuestEntryCount].status <= uint8(QuestEntryStatus.CANCELLED),
-                "INVALID_PREVIOUS_QUEST_ENTRY_STATUS"
-            );
+        // Previous user quest entry must be NOT_STARTED
+        require(
+            userQuestEntries[user][id][_userQuestEntryCount].status == uint8(QuestEntryStatus.NOT_STARTED),
+            "INVALID_PREVIOUS_QUEST_ENTRY_STATUS"
+        );
         // Add user quest entry
         userQuestEntries[user][id][_userQuestEntryCount] = UserQuestEntry({
             entryTime: block.timestamp,
@@ -165,6 +157,8 @@ LibQuest {
         });
         // Increment quest count
         quests[id].count++;
+        // Increment userQuestEntryCount
+        userQuestEntryCount[user][id] += 1;
         // Transfer entry fee to platform wallet
         require(
             token.transferFrom(
@@ -216,6 +210,8 @@ LibQuest {
             );
         // Update quest entry status
         userQuestEntries[user][id][_userQuestEntryCount].status = outcome;
+        // Increment user quest entry count
+        userQuestEntryCount[user][id] += 1;
         // Pay out user if quest was successfully finished
         if(outcome == uint8(QuestEntryStatus.SUCCESS))
             require(
@@ -245,7 +241,7 @@ LibQuest {
         // Allow only admins to cancel quests
         require(admin.admins(msg.sender), "INVALID_SENDER_ADMIN_STATUS");
         // Quest must be active
-        require(quests[id].status == uint8(QuestStatus.ACTIVE), "INVALID_QUEST_STATUS";
+        require(quests[id].status == uint8(QuestStatus.ACTIVE), "INVALID_QUEST_STATUS");
         // Cancel quest
         quests[id].status = uint8(QuestStatus.CANCELLED);
         // Emit cancel quest event
@@ -312,6 +308,8 @@ LibQuest {
             "INVALID_USER_QUEST_REFUNDED_STATUS"
         );
         userQuestEntries[msg.sender][id][_userQuestEntryCount].refunded = true;
+        // Increment user quest entry count
+        userQuestEntryCount[msg.sender][id] += 1;
         // Transfer entryFee to user
         require(
             token.transferFrom(
@@ -351,6 +349,8 @@ LibQuest {
             "INVALID_USER_QUEST_REFUNDED_STATUS"
         );
         userQuestEntries[msg.sender][id][_userQuestEntryCount].refunded = true;
+        // Increment user quest entry count
+        userQuestEntryCount[msg.sender][id] += 1;
         // Transfer entryFee to user
         require(
             token.transferFrom(

--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -157,8 +157,6 @@ LibQuest {
         });
         // Increment quest count
         quests[id].count++;
-        // Increment userQuestEntryCount
-        userQuestEntryCount[user][id] += 1;
         // Transfer entry fee to platform wallet
         require(
             token.transferFrom(

--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -195,9 +195,10 @@ LibQuest {
     ) public returns (bool) {
         // Allow only admins to set quest outcomes
         require(admin.admins(msg.sender), "INVALID_SENDER_ADMIN_STATUS");
+        uint256 _userQuestEntryCount = userQuestEntryCount[user][id];
         // User quest entry status must be STARTED
         require(
-            userQuestEntries[user][id].status == uint8(QuestEntryStatus.STARTED),
+            userQuestEntries[user][id][_userQuestEntryCount].status == uint8(QuestEntryStatus.STARTED),
             "INVALID_USER_QUEST_ENTRY_STATUS"
         );
         // Must be a valid outcome
@@ -209,12 +210,12 @@ LibQuest {
         // Outcome cannot be success if entry took longer than timeToComplete to complete
         if(outcome == uint8(QuestEntryStatus.SUCCESS))
             require(
-                (userQuestEntries[user][id].entryTime).add(quests[id].timeToComplete) >=
+                (userQuestEntries[user][id][_userQuestEntryCount].entryTime).add(quests[id].timeToComplete) >=
                 block.timestamp,
                 "INVALID_ENTRY_TIME"
             );
         // Update quest entry status
-        userQuestEntries[user][id].status = outcome;
+        userQuestEntries[user][id][_userQuestEntryCount].status = outcome;
         // Pay out user if quest was successfully finished
         if(outcome == uint8(QuestEntryStatus.SUCCESS))
             require(
@@ -269,13 +270,14 @@ LibQuest {
         require(admin.admins(msg.sender), "INVALID_SENDER_ADMIN_STATUS");
         // Quest must be active
         require(quests[id].status == uint8(QuestStatus.ACTIVE), "INVALID_QUEST_STATUS");
+        uint256 _userQuestEntryCount = userQuestEntryCount[user][id];
         // Quest entry must be started
         require(
-            userQuestEntries[user][id].status == uint8(QuestEntryStatus.STARTED),
+            userQuestEntries[user][id][_userQuestEntryCount].status == uint8(QuestEntryStatus.STARTED),
             "INVALID_USER_QUEST_ENTRY_STATUS"
         );
         // Switch quest entry status to cancelled
-        userQuestEntries[user][id].status = uint8(QuestEntryStatus.CANCELLED);
+        userQuestEntries[user][id][_userQuestEntryCount].status = uint8(QuestEntryStatus.CANCELLED);
         // Emit log cancel quest entry event
         emit LogCancelQuestEntry(
             id,
@@ -293,9 +295,10 @@ LibQuest {
     )
     public
     returns (bool) {
+        uint256 _userQuestEntryCount = userQuestEntryCount[msg.sender][id];
         // Quest entry must be started
         require(
-            userQuestEntries[msg.sender][id].status == uint8(QuestEntryStatus.STARTED),
+            userQuestEntries[msg.sender][id][_userQuestEntryCount].status == uint8(QuestEntryStatus.STARTED),
             "INVALID_USER_QUEST_ENTRY_STATUS"
         );
         // Quest should be cancelled
@@ -305,10 +308,10 @@ LibQuest {
         );
         // User quest entry cannot already be refunded
         require(
-            !userQuestEntries[msg.sender][id].refunded,
+            !userQuestEntries[msg.sender][id][_userQuestEntryCount].refunded,
             "INVALID_USER_QUEST_REFUNDED_STATUS"
         );
-        userQuestEntries[msg.sender][id].refunded = true;
+        userQuestEntries[msg.sender][id][_userQuestEntryCount].refunded = true;
         // Transfer entryFee to user
         require(
             token.transferFrom(
@@ -336,17 +339,18 @@ LibQuest {
     )
     public
     returns (bool) {
+        uint256 _userQuestEntryCount = userQuestEntryCount[msg.sender][id];
         // Quest entry must be cancelled
         require(
-            userQuestEntries[msg.sender][id].status == uint8(QuestEntryStatus.CANCELLED),
+            userQuestEntries[msg.sender][id][_userQuestEntryCount].status == uint8(QuestEntryStatus.CANCELLED),
             "INVALID_USER_QUEST_ENTRY_STATUS"
         );
         // User quest entry cannot already be refunded
         require(
-            !userQuestEntries[msg.sender][id].refunded,
+            !userQuestEntries[msg.sender][id][_userQuestEntryCount].refunded,
             "INVALID_USER_QUEST_REFUNDED_STATUS"
         );
-        userQuestEntries[msg.sender][id].refunded = true;
+        userQuestEntries[msg.sender][id][_userQuestEntryCount].refunded = true;
         // Transfer entryFee to user
         require(
             token.transferFrom(

--- a/test/Quest.js
+++ b/test/Quest.js
@@ -270,7 +270,8 @@ contract('Quest', accounts => {
         // Check if user entry exists
         const userQuestEntry = await quest.userQuestEntries(
             user1,
-            id
+            id,
+            0
         )
         const questEntryStatus_started = 1
         assert.equal(
@@ -373,7 +374,8 @@ contract('Quest', accounts => {
 
         const userQuestEntry = await quest.userQuestEntries(
             user1,
-            id
+            id,
+            0
         )
         assert.equal(
             userQuestEntry[1],
@@ -500,7 +502,8 @@ contract('Quest', accounts => {
 
         const questEntry = await quest.userQuestEntries(
             user3,
-            id
+            id,
+            0
         )
 
         const QUEST_ENTRY_STATUS_CANCELLED = 4
@@ -541,7 +544,8 @@ contract('Quest', accounts => {
 
         const userQuestEntry = await quest.userQuestEntries(
             user3,
-            id
+            id,
+            0
         )
         assert.equal(
             userQuestEntry[2],
@@ -605,7 +609,8 @@ contract('Quest', accounts => {
 
         const userQuestEntry = await quest.userQuestEntries(
             user4,
-            id
+            id,
+            0
         )
         assert.equal(
             userQuestEntry[2],

--- a/test/Quest.js
+++ b/test/Quest.js
@@ -418,6 +418,30 @@ contract('Quest', accounts => {
         )
     })
 
+    it('allows users to re-pay for quest after completing a quest', async () => {
+        const {
+            id
+        } = getValidQuestParams()
+
+        const prePayQuestCount = (await quest.quests(id)).count
+
+        // Pay for quest
+        await quest.payForQuest(
+            id,
+            user1,
+            {
+                from: user1
+            }
+        )
+
+        const postPayQuestCount = (await quest.quests(id)).count
+
+        assert.equal(
+            new BigNumber(prePayQuestCount).plus(1).toFixed(),
+            new BigNumber(postPayQuestCount).toFixed()
+        )
+    })
+
     it('quest count increments on pay for quest', async () => {
         const {id} = getValidQuestParams()
 
@@ -562,6 +586,30 @@ contract('Quest', accounts => {
                     from: user3
                 }
             )
+        )
+    })
+
+    it('allows users to re-pay for quest after claiming refunds for a cancelled user quest entry', async () => {
+        const {
+            id
+        } = getValidQuestParams()
+
+        const prePayQuestCount = (await quest.quests(id)).count
+
+        // Pay for quest
+        await quest.payForQuest(
+            id,
+            user3,
+            {
+                from: user3
+            }
+        )
+
+        const postPayQuestCount = (await quest.quests(id)).count
+
+        assert.equal(
+            new BigNumber(prePayQuestCount).plus(1).toFixed(),
+            new BigNumber(postPayQuestCount).toFixed()
         )
     })
 


### PR DESCRIPTION
Updates quest contract to account for multiple user quest entries. 

A `userQuestEntryCount` mapping has been added to count unique user quest entries for each quest. This is incremented after a user quest entry is either completed or if a user claims refunds after a quest or a quest entry is cancelled. `payForQuest` can be called as long as `userQuestEntries[id][user][userQuestEntryCount].status == UserQuestEntryStatus.NOT_STARTED`

Quest tests have been updated to handle changes in `userQuestEntries` and adds additional test cases to account for multiple user quest entries.