### PR TITLE
Node fixes

### DIFF
--- a/contracts/node/DBETNode.sol
+++ b/contracts/node/DBETNode.sol
@@ -62,7 +62,8 @@ LibDBETNode {
         address indexed user
     );
     event LogNewNode(
-        uint256 indexed id
+        uint256 indexed id,
+        uint8 indexed nodeType
     );
 
     constructor(
@@ -295,6 +296,7 @@ LibDBETNode {
     * @param rewards Array of reward IDs linked to this node type
     * @param entryFeeDiscount Entry fee discount
     * @param increasedPrizePayout % increment on prizes won from quests by node holders
+    * @param nodeType Type of node
     * @return Whether node was added
     */
     function addNode(
@@ -304,7 +306,8 @@ LibDBETNode {
         uint256 maxCount,
         uint8[] memory rewards,
         uint256 entryFeeDiscount,
-        uint256 increasedPrizePayout
+        uint256 increasedPrizePayout,
+        uint8 nodeType
     )
     public
     returns (bool) {
@@ -351,6 +354,12 @@ LibDBETNode {
             rewards.length <= uint8(Rewards.CREATE_TOURNAMENT) + 1,
             "INVALID_REWARDS_ARRAY_LENGTH"
         );
+        // Must be a valid node type
+        require(
+            nodeType >= 0 &&
+            nodeType <= uint8(NodeType.REWARD_NODE),
+            "INVALID_NODE_TYPE"
+        );
         // Validate rewards array
         for (uint256 i = 0; i < rewards.length; i++) {
             // TODO: Check for duplicates
@@ -370,9 +379,13 @@ LibDBETNode {
             rewards: rewards,
             entryFeeDiscount: entryFeeDiscount,
             increasedPrizePayout: increasedPrizePayout,
-            count: 0
+            count: 0,
+            nodeType: nodeType
         });
-        emit LogNewNode(nodeCount);
+        emit LogNewNode(
+            nodeCount,
+            nodeType
+        );
         return true;
     }
 

--- a/contracts/node/DBETNode.sol
+++ b/contracts/node/DBETNode.sol
@@ -65,6 +65,9 @@ LibDBETNode {
         uint256 indexed id,
         uint8 indexed nodeType
     );
+    event LogDeprecatedNode(
+        uint256 indexed id
+    );
 
     constructor(
         address _admin,
@@ -380,13 +383,45 @@ LibDBETNode {
             entryFeeDiscount: entryFeeDiscount,
             increasedPrizePayout: increasedPrizePayout,
             count: 0,
-            nodeType: nodeType
+            nodeType: nodeType,
+            deprecated: false
         });
         emit LogNewNode(
             nodeCount,
             nodeType
         );
         return true;
+    }
+
+    /**
+    * Deprecates an existing node type. Deprecated node types would be hidden from the UI
+    * @param node Unique ID of node type
+    * @return Whether node type was deprecated
+    */
+    function deprecateNode(
+        uint256 node
+    )
+    public
+    returns (bool) {
+        // Sender must be an admin
+        require(
+            admin.admins(msg.sender),
+            "INVALID_SENDER"
+        );
+        // Must be a valid node type
+        require(
+            nodes[node].timeThreshold != 0,
+            "INVALID_NODE_TYPE"
+        );
+        // Must not already be deprecated
+        require(
+            !nodes[node].deprecated,
+            "NODE_TYPE_ALREADY_DEPRECATED"
+        );
+        nodes[node].deprecated = true;
+        emit LogDeprecatedNode(
+            node
+        );
     }
 
     /**

--- a/contracts/node/interfaces/IDBETNode.sol
+++ b/contracts/node/interfaces/IDBETNode.sol
@@ -33,6 +33,7 @@ contract IDBETNode {
     * @param rewards Array of reward IDs linked to this node type
     * @param entryFeeDiscount Entry fee discount
     * @param increasedPrizePayout % increment on prizes won from quests by node holders
+    * @param nodeType Type of node
     * @return Whether node was added
     */
     function addNode(
@@ -42,7 +43,8 @@ contract IDBETNode {
         uint256 maxCount,
         uint8[] memory rewards,
         uint256 entryFeeDiscount,
-        uint256 increasedPrizePayout
+        uint256 increasedPrizePayout,
+        uint8 nodeType
     )
     public
     returns (bool);

--- a/contracts/node/libs/LibDBETNode.sol
+++ b/contracts/node/libs/LibDBETNode.sol
@@ -37,6 +37,8 @@ contract LibDBETNode {
         uint256 count;
         // Node type
         uint8 nodeType;
+        // If deprecated this node tier will be deemed invalid
+        bool deprecated;
     }
 
     // User node

--- a/contracts/node/libs/LibDBETNode.sol
+++ b/contracts/node/libs/LibDBETNode.sol
@@ -35,6 +35,8 @@ contract LibDBETNode {
         uint256 increasedPrizePayout;
         // Number of nodes created of this type
         uint256 count;
+        // Node type
+        uint8 nodeType;
     }
 
     // User node

--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -739,7 +739,7 @@ LibQuest {
     public
     view
     returns (uint256) {
-        (,,,,uint256 discount,,,) = dbetNode.nodes(nodeType);
+        (,,,,uint256 discount,,,,) = dbetNode.nodes(nodeType);
         // entryFee * (1 - discount)/100
         return entryFee.mul(uint256(100).sub(discount)).div(100);
     }
@@ -757,7 +757,7 @@ LibQuest {
     public
     view
     returns (uint256) {
-        (,,,,,uint256 increasedPrizePayout,,) = dbetNode.nodes(nodeType);
+        (,,,,,uint256 increasedPrizePayout,,,) = dbetNode.nodes(nodeType);
         // prize + ((prize * increasedPrizePayout/100))
         return prize.add(prize.mul(increasedPrizePayout).div(100));
     }

--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -145,7 +145,7 @@ LibQuest {
     returns (bool) {
         // Allow only active node holders to add quests
         require(
-            isActiveNode(
+            isActiveHouseNode(
                 nodeId,
                 msg.sender
             ),
@@ -242,9 +242,9 @@ LibQuest {
     ) public returns (bool) {
         // Must be a valid quest ID
         require(quests[id].status == uint8(QuestStatus.ACTIVE), "INVALID_QUEST_ID");
-        // Allow only active node holders to pay for quests
+        // Allow only active `INCREASED_PRIZE_PAYOUT` node holders to pay for quests
         require(
-            isActiveNode(
+            isActiveIncreasedPrizePayoutNode(
                 nodeId,
                 user
             ),
@@ -315,7 +315,7 @@ LibQuest {
         if (quests[id].isNode) {
             // Check if node is active
             require(
-                isActiveNode(
+                isActiveHouseNode(
                     quests[id].nodeId,
                     dbetNode.getNodeOwner(quests[id].nodeId)
                 ),
@@ -480,7 +480,7 @@ LibQuest {
     returns (bool) {
         // Allow only active node holders to cancel their nodes' quests
         require(
-            isActiveNode(
+            isActiveHouseNode(
                 nodeId,
                 msg.sender
             ),
@@ -687,12 +687,12 @@ LibQuest {
     }
 
     /**
-    * Returns whether an input node ID and owner is valid and active
+    * Returns whether an input node ID and owner is a valid house node and active
     * @param id Unique node ID
-    * @param nodeOwner Address of node owner
+    * @param nodeOwner Address of house node owner
     * @return Whether node is active
     */
-    function isActiveNode(
+    function isActiveHouseNode(
         uint256 id,
         address nodeOwner
     )
@@ -702,6 +702,26 @@ LibQuest {
         return (
             dbetNode.isUserNodeActivated(id) &&
             dbetNode.isQuestNode(id) &&
+            dbetNode.getNodeOwner(id) == nodeOwner
+        );
+    }
+
+    /**
+    * Returns whether an input node ID and owner is a valid increased prize payout node and active
+    * @param id Unique node ID
+    * @param nodeOwner Address of house node owner
+    * @return Whether node is active
+    */
+    function isActiveIncreasedPrizePayoutNode(
+        uint256 id,
+        address nodeOwner
+    )
+    public
+    view
+    returns (bool) {
+        return (
+            dbetNode.isUserNodeActivated(id) &&
+            dbetNode.isIncreasedPrizePayoutNode(id) &&
             dbetNode.getNodeOwner(id) == nodeOwner
         );
     }

--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -739,7 +739,7 @@ LibQuest {
     public
     view
     returns (uint256) {
-        (,,,,uint256 discount,,) = dbetNode.nodes(nodeType);
+        (,,,,uint256 discount,,,) = dbetNode.nodes(nodeType);
         // entryFee * (1 - discount)/100
         return entryFee.mul(uint256(100).sub(discount)).div(100);
     }
@@ -757,7 +757,7 @@ LibQuest {
     public
     view
     returns (uint256) {
-        (,,,,,uint256 increasedPrizePayout,) = dbetNode.nodes(nodeType);
+        (,,,,,uint256 increasedPrizePayout,,) = dbetNode.nodes(nodeType);
         // prize + ((prize * increasedPrizePayout/100))
         return prize.add(prize.mul(increasedPrizePayout).div(100));
     }

--- a/contracts/tournament/Tournament.sol
+++ b/contracts/tournament/Tournament.sol
@@ -999,7 +999,7 @@ LibDBETNode {
     public
     view
     returns (uint256) {
-        (,,,,uint256 discount,,) = dbetNode.nodes(nodeType);
+        (,,,,uint256 discount,,,) = dbetNode.nodes(nodeType);
         // entryFee * (1 - discount)/100
         return entryFee.mul(uint256(100).sub(discount)).div(100);
     }

--- a/contracts/tournament/Tournament.sol
+++ b/contracts/tournament/Tournament.sol
@@ -999,7 +999,7 @@ LibDBETNode {
     public
     view
     returns (uint256) {
-        (,,,,uint256 discount,,,) = dbetNode.nodes(nodeType);
+        (,,,,uint256 discount,,,,) = dbetNode.nodes(nodeType);
         // entryFee * (1 - discount)/100
         return entryFee.mul(uint256(100).sub(discount)).div(100);
     }

--- a/migrations/vet/migrationscript.js
+++ b/migrations/vet/migrationscript.js
@@ -11,6 +11,7 @@ function MigrationScript(web3, contractManager, deployer, builder, args) {
 
     let admin,
         dbetNode,
+        nodeWallet,
         quest,
         token,
         tournament
@@ -140,10 +141,21 @@ function MigrationScript(web3, contractManager, deployer, builder, args) {
                     tournament.options.address
                 ).send(getDefaultOptions())
 
+                const nodeWalletAddress = await dbetNode.methods.nodeWallet().call()
+                const NodeWallet = contractManager.getContract(
+                    'NodeWallet',
+                    nodeWalletAddress
+                )
+                nodeWallet = new web3.eth.Contract(
+                    NodeWallet._jsonInterface,
+                    nodeWalletAddress
+                )
+
                 console.log(
                     'Deployed:',
                     '\nAdmin: ' + admin.options.address,
                     '\nDBETNode: ' + dbetNode.options.address,
+                    '\nNodeWallet: ' + nodeWallet.options.address,
                     '\nQuest: ' + quest.options.address,
                     '\nToken: ' + token.options.address,
                     '\nTournament: ' + tournament.options.address
@@ -155,6 +167,7 @@ function MigrationScript(web3, contractManager, deployer, builder, args) {
 
                 builder.addContract("AdminContract", Admin, admin.options.address, chain)
                 builder.addContract("DBETNode", DBETNode, dbetNode.options.address, chain)
+                builder.addContract("NodeWallet", NodeWallet, nodeWallet.options.address, chain)
                 builder.addContract("QuestContract", Quest, quest.options.address, chain)
                 builder.addContract("DBETVETTokenContract", DecentBetToken, token.options.address, chain)
                 builder.addContract("TournamentContract", Tournament, tournament.options.address, chain)
@@ -270,10 +283,21 @@ function MigrationScript(web3, contractManager, deployer, builder, args) {
                     tournament.options.address
                 ).send(getDefaultOptions())
 
+                const nodeWalletAddress = await dbetNode.methods.nodeWallet().call()
+                const NodeWallet = contractManager.getContract(
+                    'NodeWallet',
+                    nodeWalletAddress
+                )
+                nodeWallet = new web3.eth.Contract(
+                    NodeWallet._jsonInterface,
+                    nodeWalletAddress
+                )
+
                 console.log(
                     'Deployed:',
                     '\nAdmin: ' + admin.options.address,
                     '\nDBETNode: ' + dbetNode.options.address,
+                    '\nNodeWallet: ' + nodeWallet.options.address,
                     '\nQuest: ' + quest.options.address,
                     '\nTournament: ' + tournament.options.address
                 )
@@ -284,6 +308,7 @@ function MigrationScript(web3, contractManager, deployer, builder, args) {
 
                 builder.addContract("AdminContract", Admin, admin.options.address, chain)
                 builder.addContract("DBETNode", DBETNode, dbetNode.options.address, chain)
+                builder.addContract("NodeWallet", NodeWallet, nodeWallet.options.address, chain)
                 builder.addContract("QuestContract", Quest, quest.options.address, chain)
                 builder.addContract("DBETVETTokenContract", DecentBetToken, token.options.address, chain)
                 builder.addContract("TournamentContract", Tournament, tournament.options.address, chain)

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    "VERSION": "1.0.13",
+    "VERSION": "1.0.14",
     "AdminContract": {
         "raw": {
             "abi": [{
@@ -98,7 +98,7 @@ module.exports = {
             }]
         },
         "address": {
-            "0x27": "0xE228b04Ed3979B89beB19250Aa2182FF9104747a",
+            "0x27": "0x0aEB52F3ed81dd732C1b7513dBed74BF40930753",
             "0xc7": "0x9FD9EaEdCB8621FEc90EE7538B72cde0406396bc",
             "0x4a": "0xE1A9dA3a8E10B74AB05Bc068272254C242DaFb4D",
             "0xa4": "0xbAa4774602Dc5571FebcEa7D3cf966297Cb3f1BF"
@@ -119,7 +119,10 @@ module.exports = {
                 }, {"name": "entryFeeDiscount", "type": "uint256"}, {
                     "name": "increasedPrizePayout",
                     "type": "uint256"
-                }, {"name": "count", "type": "uint256"}],
+                }, {"name": "count", "type": "uint256"}, {"name": "nodeType", "type": "uint8"}, {
+                    "name": "deprecated",
+                    "type": "bool"
+                }],
                 "payable": false,
                 "stateMutability": "view",
                 "type": "function",
@@ -168,15 +171,6 @@ module.exports = {
                 "signature": "0x51964f3a"
             }, {
                 "constant": true,
-                "inputs": [{"name": "", "type": "address"}, {"name": "", "type": "uint256"}],
-                "name": "nodeOwnership",
-                "outputs": [{"name": "", "type": "bool"}],
-                "payable": false,
-                "stateMutability": "view",
-                "type": "function",
-                "signature": "0x65f1b165"
-            }, {
-                "constant": true,
                 "inputs": [],
                 "name": "nodeCount",
                 "outputs": [{"name": "", "type": "uint256"}],
@@ -193,6 +187,15 @@ module.exports = {
                 "stateMutability": "view",
                 "type": "function",
                 "signature": "0x8da5cb5b"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "address"}],
+                "name": "nodeOwnership",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0xac05a44d"
             }, {
                 "constant": true,
                 "inputs": [],
@@ -249,13 +252,13 @@ module.exports = {
             }, {
                 "anonymous": false,
                 "inputs": [{"indexed": true, "name": "id", "type": "uint256"}, {
-                    "indexed": false,
+                    "indexed": true,
                     "name": "previousNodeType",
                     "type": "uint256"
-                }],
+                }, {"indexed": true, "name": "newNodeType", "type": "uint256"}],
                 "name": "LogUpgradeUserNode",
                 "type": "event",
-                "signature": "0x9a5479b8e6bbf8fad2b1dc7d477f4035c655b7808590d8e139042fe1d24d8269"
+                "signature": "0x0dd9a48df69e33423c399bd9cd993b74dcd7d7463400ccd0b1d19e2ceb83dca3"
             }, {
                 "anonymous": false,
                 "inputs": [{"indexed": true, "name": "id", "type": "uint256"}, {
@@ -268,10 +271,20 @@ module.exports = {
                 "signature": "0x3376c15012e84e96494909f552c426052f0cf2d207b963d5bb16470e9734d180"
             }, {
                 "anonymous": false,
-                "inputs": [{"indexed": true, "name": "id", "type": "uint256"}],
+                "inputs": [{"indexed": true, "name": "id", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "nodeType",
+                    "type": "uint8"
+                }],
                 "name": "LogNewNode",
                 "type": "event",
-                "signature": "0xfd87414d354ab22a67e24dc515e141be1f584cb4c6ea9f287c1a842be0b330fb"
+                "signature": "0xc2534f6a446b4ab6fbba2bc99c5f88915195345f4a13e909e323ff656bce5882"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "id", "type": "uint256"}],
+                "name": "LogDeprecatedNode",
+                "type": "event",
+                "signature": "0x343996fb6a78d672d92fe175deb9278e646a31ec144c0d8367a046097c6c55f1"
             }, {
                 "constant": false,
                 "inputs": [{"name": "_quest", "type": "address"}, {"name": "_tournament", "type": "address"}],
@@ -319,13 +332,22 @@ module.exports = {
                 }, {"name": "rewards", "type": "uint8[]"}, {
                     "name": "entryFeeDiscount",
                     "type": "uint256"
-                }, {"name": "increasedPrizePayout", "type": "uint256"}],
+                }, {"name": "increasedPrizePayout", "type": "uint256"}, {"name": "nodeType", "type": "uint8"}],
                 "name": "addNode",
                 "outputs": [{"name": "", "type": "bool"}],
                 "payable": false,
                 "stateMutability": "nonpayable",
                 "type": "function",
-                "signature": "0x404d0fd2"
+                "signature": "0x32ea73a0"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "node", "type": "uint256"}],
+                "name": "deprecateNode",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0xc6b8774b"
             }, {
                 "constant": true,
                 "inputs": [{"name": "id", "type": "uint256"}],
@@ -337,16 +359,7 @@ module.exports = {
                 "signature": "0xfe12bdd6"
             }, {
                 "constant": true,
-                "inputs": [{"name": "user", "type": "address"}, {"name": "node", "type": "uint256"}],
-                "name": "isUserNodeOwner",
-                "outputs": [{"name": "", "type": "bool"}],
-                "payable": false,
-                "stateMutability": "view",
-                "type": "function",
-                "signature": "0x3a8d300e"
-            }, {
-                "constant": true,
-                "inputs": [{"name": "id", "type": "uint256"}],
+                "inputs": [{"name": "userNodeId", "type": "uint256"}],
                 "name": "getNodeOwner",
                 "outputs": [{"name": "", "type": "address"}],
                 "payable": false,
@@ -355,7 +368,7 @@ module.exports = {
                 "signature": "0x5d3c373f"
             }, {
                 "constant": true,
-                "inputs": [{"name": "id", "type": "uint256"}],
+                "inputs": [{"name": "userNodeId", "type": "uint256"}],
                 "name": "isQuestNode",
                 "outputs": [{"name": "", "type": "bool"}],
                 "payable": false,
@@ -364,491 +377,27 @@ module.exports = {
                 "signature": "0x8a71edcf"
             }, {
                 "constant": true,
-                "inputs": [{"name": "id", "type": "uint256"}],
+                "inputs": [{"name": "userNodeId", "type": "uint256"}],
                 "name": "isTournamentNode",
                 "outputs": [{"name": "", "type": "bool"}],
                 "payable": false,
                 "stateMutability": "view",
                 "type": "function",
                 "signature": "0x8533022a"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "userNodeId", "type": "uint256"}],
+                "name": "isIncreasedPrizePayoutNode",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0x7d434b2d"
             }]
         },
         "address": {
-            "0x27": "0x46b4DA77DC4142702963531bB1B895C2aC731408",
+            "0x27": "0xED51F4Ff6cb278dfDe274B1e18cD6fA1618E73ad",
             "0xa4": "0xA867c87682D7c5ebe92046D1ddd9F1930B8B55BC"
-        }
-    },
-    "NodeWallet": {
-        "raw": {
-            "abi": [
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "prizeFund",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "totalCompletedQuestPrizePayouts",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [],
-                    "name": "dbetNode",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "totalRakeFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "questFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "rakeFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "totalCompletedQuestEntryFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "constant": true,
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "totalQuestEntryFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "constructor"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "questId",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "LogSetPrizeFund",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "questId",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "LogAddQuestEntryFee",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "questId",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "LogAddCompletedQuestEntryFee",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "questId",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "LogClaimRefund",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "amount",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "LogWithdrawCompletedQuestEntryFees",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "tournamentId",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "LogAddTournamentRakeFees",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": true,
-                            "name": "amount",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "LogWithdrawTournamentRakeFees",
-                    "type": "event"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "questId",
-                            "type": "bytes32"
-                        },
-                        {
-                            "name": "fund",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "setPrizeFund",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "questId",
-                            "type": "bytes32"
-                        },
-                        {
-                            "name": "fee",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "addQuestEntryFee",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "questId",
-                            "type": "bytes32"
-                        },
-                        {
-                            "name": "fee",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "prize",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "completeQuest",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "questId",
-                            "type": "bytes32"
-                        },
-                        {
-                            "name": "fee",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "claimRefund",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "withdrawCompletedQuestEntryFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        },
-                        {
-                            "name": "tournamentId",
-                            "type": "bytes32"
-                        },
-                        {
-                            "name": "rakeFee",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "addTournamentRakeFee",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "constant": false,
-                    "inputs": [
-                        {
-                            "name": "nodeId",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "withdrawTournamentRakeFees",
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "payable": false,
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                }
-            ]
-        },
-        "address": {
-            "0x27": "0x9E46b0e72052d8caa86B9633988F603973591c1D",
-            "0xc7": "0x9E46b0e72052d8caa86B9633988F603973591c1D",
-            "0x4a": "0x9E46b0e72052d8caa86B9633988F603973591c1D",
-            "0xa4": "0x9E46b0e72052d8caa86B9633988F603973591c1D"
         }
     },
     "QuestContract": {
@@ -863,7 +412,7 @@ module.exports = {
                 "outputs": [{"name": "entryTime", "type": "uint256"}, {
                     "name": "entryFee",
                     "type": "uint256"
-                }, {"name": "nodeId", "type": "uint256"}, {"name": "status", "type": "uint8"}, {
+                }, {"name": "status", "type": "uint8"}, {"name": "nodeId", "type": "uint256"}, {
                     "name": "refunded",
                     "type": "bool"
                 }],
@@ -1108,12 +657,21 @@ module.exports = {
             }, {
                 "constant": true,
                 "inputs": [{"name": "id", "type": "uint256"}, {"name": "nodeOwner", "type": "address"}],
-                "name": "isActiveNode",
+                "name": "isActiveHouseNode",
                 "outputs": [{"name": "", "type": "bool"}],
                 "payable": false,
                 "stateMutability": "view",
                 "type": "function",
-                "signature": "0x874fa1a1"
+                "signature": "0xbbd31d73"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "id", "type": "uint256"}, {"name": "nodeOwner", "type": "address"}],
+                "name": "isActiveIncreasedPrizePayoutNode",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0xf814ff21"
             }, {
                 "constant": true,
                 "inputs": [{"name": "nodeType", "type": "uint256"}, {"name": "entryFee", "type": "uint256"}],
@@ -1135,10 +693,246 @@ module.exports = {
             }]
         },
         "address": {
-            "0x27": "0x08ff493FA0e09981B0c996dAd7a67B0085B2eBD6",
+            "0x27": "0xf5b296dd218cE165dE9fDda0eDa56Fdd15fA21C4",
             "0xc7": "0x55db2feE8A2A039BCA83b014cf0b455a31E77Cda",
             "0x4a": "0x0E599Dc9e307251729Dbf05Be79E61E0165f3FbF",
             "0xa4": "0x975f12947bA0654a56873F8236E5c9b5C498c874"
+        }
+    },
+    "NodeWallet": {
+        "raw": {
+            "abi": [{
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}, {"name": "", "type": "bytes32"}],
+                "name": "prizeFund",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0x319e46f5"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}],
+                "name": "totalCompletedQuestPrizePayouts",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0x46fb2cae"
+            }, {
+                "constant": true,
+                "inputs": [],
+                "name": "dbetNode",
+                "outputs": [{"name": "", "type": "address"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0x53f7eb90"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}],
+                "name": "totalRakeFees",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0x7308a021"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}, {"name": "", "type": "bytes32"}],
+                "name": "questFees",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0x9236f624"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}, {"name": "", "type": "bytes32"}],
+                "name": "rakeFees",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0xc4ded9d5"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}],
+                "name": "totalCompletedQuestEntryFees",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0xc91a64a0"
+            }, {
+                "constant": true,
+                "inputs": [{"name": "", "type": "uint256"}],
+                "name": "totalQuestEntryFees",
+                "outputs": [{"name": "", "type": "uint256"}],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function",
+                "signature": "0xceaac89f"
+            }, {
+                "inputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "questId",
+                    "type": "bytes32"
+                }],
+                "name": "LogSetPrizeFund",
+                "type": "event",
+                "signature": "0x0139e7e874fbcf19d90f8ad114d5f294ee5e36c2a92da5334a42c97268f0030f"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "questId",
+                    "type": "bytes32"
+                }],
+                "name": "LogAddQuestEntryFee",
+                "type": "event",
+                "signature": "0x00a6b81229b4ebfc07e6b9a7de389506517383dd38a76ebf60ee23986ad01c35"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "questId",
+                    "type": "bytes32"
+                }],
+                "name": "LogAddCompletedQuestEntryFee",
+                "type": "event",
+                "signature": "0x7501ebdab1c1f68475f61e42ef7b4d8ac330131e2202bed3c85a4ad1f17359a4"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "questId",
+                    "type": "bytes32"
+                }],
+                "name": "LogClaimRefund",
+                "type": "event",
+                "signature": "0xf7ab3c1383080a8912888a37804d4153bb74e80eb73ed44131a8e15c5726ab2d"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "amount",
+                    "type": "uint256"
+                }],
+                "name": "LogWithdrawCompletedQuestEntryFees",
+                "type": "event",
+                "signature": "0x2ddd7d38c89622e82ff6893431cff5d4f115d3e3b0e8c5871c854e593a60f256"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "tournamentId",
+                    "type": "bytes32"
+                }],
+                "name": "LogAddTournamentRakeFees",
+                "type": "event",
+                "signature": "0x3090809ec27599283b97ee582f754e77fdf6b508a81ed0725e9d988a182fff48"
+            }, {
+                "anonymous": false,
+                "inputs": [{"indexed": true, "name": "nodeId", "type": "uint256"}, {
+                    "indexed": true,
+                    "name": "amount",
+                    "type": "uint256"
+                }],
+                "name": "LogWithdrawTournamentRakeFees",
+                "type": "event",
+                "signature": "0x4b1caf238fdd995ea2c279896256e886e9f8488a7ae3aab750165b9cd3652291"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}, {
+                    "name": "questId",
+                    "type": "bytes32"
+                }, {"name": "fund", "type": "uint256"}],
+                "name": "setPrizeFund",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0xd614ef25"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}, {
+                    "name": "questId",
+                    "type": "bytes32"
+                }, {"name": "fee", "type": "uint256"}],
+                "name": "addQuestEntryFee",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0x114b69dc"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}, {
+                    "name": "questId",
+                    "type": "bytes32"
+                }, {"name": "fee", "type": "uint256"}, {"name": "prize", "type": "uint256"}],
+                "name": "completeQuest",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0x574f7ef5"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}, {
+                    "name": "questId",
+                    "type": "bytes32"
+                }, {"name": "fee", "type": "uint256"}],
+                "name": "claimRefund",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0x5e2d7f12"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}],
+                "name": "withdrawCompletedQuestEntryFees",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0xc4585d61"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}, {
+                    "name": "tournamentId",
+                    "type": "bytes32"
+                }, {"name": "rakeFee", "type": "uint256"}],
+                "name": "addTournamentRakeFee",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0xa49e22e5"
+            }, {
+                "constant": false,
+                "inputs": [{"name": "nodeId", "type": "uint256"}],
+                "name": "withdrawTournamentRakeFees",
+                "outputs": [{"name": "", "type": "bool"}],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function",
+                "signature": "0x13406de4"
+            }]
+        },
+        "address": {
+            "0x27": "0x0e6E93927afd058B4673844BE317Ea855aBb47cC",
+            "0xc7": "0x9E46b0e72052d8caa86B9633988F603973591c1D",
+            "0x4a": "0x9E46b0e72052d8caa86B9633988F603973591c1D",
+            "0xa4": "0x9E46b0e72052d8caa86B9633988F603973591c1D"
         }
     },
     "DBETVETTokenContract": {
@@ -1741,7 +1535,7 @@ module.exports = {
             }]
         },
         "address": {
-            "0x27": "0xA5663eB0F2AF3c869Dc599db2567293dB5242Bd8",
+            "0x27": "0x6525ffA81423e4f1dc4fc7435806ea563DeDf259",
             "0xc7": "0x9FD9EaEdCB8621FEc90EE7538B72cde0406396bc",
             "0x4a": "0x5dc557E3b082ecA7c6EA890f806F5bddE4D39d50",
             "0xa4": "0xacc34b6a1FcC2cBE08b08f2db9b023Dcdb6C6Fc4"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@decent-bet/contract-playdbet",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "Contracts for PlayDBET Platform",
     "main": "index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playdbet-contracts",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "index.js",
   "author": "dev <dev@decent.bet>",
   "license": "GPL-3.0",

--- a/test/DBETNode.js
+++ b/test/DBETNode.js
@@ -48,7 +48,8 @@ contract('DBETNode', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         } = getHouseNode()
 
         await utils.assertFail(
@@ -60,6 +61,7 @@ contract('DBETNode', accounts => {
                 rewards,
                 entryFeeDiscount,
                 increasedPrizePayout,
+                nodeType,
                 {
                     from: user1
                 }
@@ -76,7 +78,8 @@ contract('DBETNode', accounts => {
                 maxCount,
                 rewards,
                 entryFeeDiscount,
-                increasedPrizePayout
+                increasedPrizePayout,
+                nodeType
             } = node
 
             await dbetNode.addNode(
@@ -86,14 +89,15 @@ contract('DBETNode', accounts => {
                 maxCount,
                 rewards,
                 entryFeeDiscount,
-                increasedPrizePayout
+                increasedPrizePayout,
+                nodeType
             )
 
-            const nodeType = await dbetNode.nodes(index)
+            const _node = await dbetNode.nodes(index)
 
             assert.equal(
                 name,
-                nodeType.name
+                _node.name
             )
         }
 

--- a/test/DBETNode.js
+++ b/test/DBETNode.js
@@ -361,4 +361,39 @@ contract('DBETNode', accounts => {
         )
     })
 
+    it('does not allow non-admins to deprecate valid nodes', async () => {
+        await utils.assertFail(
+            dbetNode.deprecateNode(
+                NODE_ID_UPGRADED,
+                {
+                    from: user1
+                }
+            )
+        )
+    })
+
+    it('does not allow admins to deprecate invalid nodes', async () => {
+        await utils.assertFail(
+            dbetNode.deprecateNode(
+                0,
+                {
+                    from: user1
+                }
+            )
+        )
+    })
+
+    it('allows admins to deprecate valid nodes', async () => {
+        await dbetNode.deprecateNode(
+            NODE_ID_UPGRADED
+        )
+
+        const node = await dbetNode.nodes(NODE_ID_UPGRADED)
+        const {deprecated} = node
+        assert.equal(
+            deprecated,
+            true
+        )
+    })
+
 })

--- a/test/DBETNode.js
+++ b/test/DBETNode.js
@@ -4,7 +4,7 @@ const timeTraveler = require('ganache-time-traveler')
 const contracts = require('./utils/contracts')
 const utils = require('./utils/utils')
 const {
-    getNode,
+    getHouseNode,
     getUpgradedNode
 } = require('./utils/nodes')
 
@@ -24,7 +24,7 @@ const timeTravel = async timeDiff => {
 }
 
 const getNodeUpgradeTokenRequirement = () => {
-    const tier1TokenThreshold = getNode().tokenThreshold
+    const tier1TokenThreshold = getHouseNode().tokenThreshold
     const tier2TokenThreshold = getUpgradedNode().tokenThreshold
     return new BigNumber(tier2TokenThreshold).minus(tier1TokenThreshold).toFixed()
 }
@@ -49,7 +49,7 @@ contract('DBETNode', accounts => {
             rewards,
             entryFeeDiscount,
             increasedPrizePayout
-        } = getNode()
+        } = getHouseNode()
 
         await utils.assertFail(
             dbetNode.addNode(
@@ -97,19 +97,19 @@ contract('DBETNode', accounts => {
             )
         }
 
-        await addNode(getNode(), 0)
-        await addNode(getUpgradedNode(), 1)
+        await addNode(getHouseNode(), 1)
+        await addNode(getUpgradedNode(), 2)
     })
 
     it('does not allow users without an approved DBET balance to create a node', async () => {
         const {
             tokenThreshold
-        } = getNode()
+        } = getHouseNode()
 
         const _assertFailCreateNode = () => {
             utils.assertFail(
                 dbetNode.create(
-                    0,
+                    1,
                     {
                         from: user1
                     }
@@ -136,9 +136,9 @@ contract('DBETNode', accounts => {
                 from: user1
             }
         )
-        // Create node of type ID 0
+        // Create node of type ID 1
         await dbetNode.create(
-            0,
+            1,
             {
                 from: user1
             }
@@ -205,7 +205,7 @@ contract('DBETNode', accounts => {
         // Upgrade node to Tier II
         await dbetNode.upgrade(
             1,
-            1,
+            2,
             {
                 from: user1
             }
@@ -223,8 +223,8 @@ contract('DBETNode', accounts => {
         const userNode = await dbetNode.userNodes(1)
         // Node must be owned by user
         assert.equal(userNode.owner, user1)
-        // Node must be of type 1
-        assert.equal(userNode.node, 1)
+        // Node must be of type 2
+        assert.equal(userNode.node, 2)
         // Node must not be activated
         assert.equal(await dbetNode.isUserNodeActivated(1), false)
         // Activate node
@@ -276,9 +276,9 @@ contract('DBETNode', accounts => {
     })
 
     it('nodes are not active if they don\'t meet time threshold', async () => {
-        // Create node of type ID 0
+        // Create node of type ID 1
         await dbetNode.create(
-            0,
+            1,
             {
                 from: user1
             }
@@ -295,7 +295,7 @@ contract('DBETNode', accounts => {
     it('nodes are active if they meet time threshold', async () => {
         const {
             timeThreshold
-        } = getNode()
+        } = getHouseNode()
         await timeTravel(timeThreshold)
 
         const isUserNodeActivated = await dbetNode.isUserNodeActivated(2)

--- a/test/NodeWallet.js
+++ b/test/NodeWallet.js
@@ -4,7 +4,7 @@ const timeTraveler = require('ganache-time-traveler')
 const contracts = require('./utils/contracts')
 const utils = require('./utils/utils')
 const {
-    getNode,
+    getHouseNode,
     getValidNodeQuestParams
 } = require('./utils/nodes')
 const {
@@ -107,7 +107,7 @@ contract('NodeWallet', accounts => {
             rewards,
             entryFeeDiscount,
             increasedPrizePayout
-        } = getNode()
+        } = getHouseNode()
         await dbetNode.addNode(
             name,
             tokenThreshold,
@@ -133,9 +133,9 @@ contract('NodeWallet', accounts => {
                 from: nodeHolder
             }
         )
-        // Create node of type ID 0
+        // Create node of type ID 1
         await dbetNode.create(
-            0,
+            1,
             {
                 from: nodeHolder
             }

--- a/test/NodeWallet.js
+++ b/test/NodeWallet.js
@@ -106,7 +106,8 @@ contract('NodeWallet', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         } = getHouseNode()
         await dbetNode.addNode(
             name,
@@ -115,7 +116,8 @@ contract('NodeWallet', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         )
 
         // Approve tokens to be transferred on behalf of user from DBETNode and Quest contracts

--- a/test/Quest.js
+++ b/test/Quest.js
@@ -689,7 +689,8 @@ contract('Quest', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         } = getHouseNode()
         await dbetNode.addNode(
             name,
@@ -698,7 +699,8 @@ contract('Quest', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         )
 
         // Approve tokens to be transferred on behalf of user from DBETNode and Quest contracts
@@ -884,7 +886,8 @@ contract('Quest', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         } = getIncreasedPrizePayoutNode()
         await dbetNode.addNode(
             name,
@@ -893,7 +896,8 @@ contract('Quest', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         )
         // Approve tokens to be transferred on behalf of user from DBETNode and Quest contracts
         await token.approve(

--- a/test/Quest.js
+++ b/test/Quest.js
@@ -25,7 +25,7 @@ let user2
 let user3
 let user4
 let houseNodeHolder
-let rewardNodeHolder
+let increasedPrizePayoutNodeHolder
 
 const web3 = new Web3()
 
@@ -53,7 +53,7 @@ contract('Quest', accounts => {
         user3 = accounts[3]
         user4 = accounts[4]
         houseNodeHolder = accounts[5]
-        rewardNodeHolder = accounts[6]
+        increasedPrizePayoutNodeHolder = accounts[6]
 
         dbetNode = await contracts.DBETNode.deployed()
         quest = await contracts.Quest.deployed()
@@ -875,7 +875,7 @@ contract('Quest', accounts => {
     it('pays discounted fees if node holders pays for quest', async () => {
         // Transfer DBETs to reward node holder
         await token.transfer(
-            rewardNodeHolder,
+            increasedPrizePayoutNodeHolder,
             web3.utils.toWei('2000000', 'ether')
         )
         // Add a new node type as admin
@@ -904,21 +904,21 @@ contract('Quest', accounts => {
             dbetNode.address,
             utils.MAX_VALUE,
             {
-                from: rewardNodeHolder
+                from: increasedPrizePayoutNodeHolder
             }
         )
         await token.approve(
             quest.address,
             utils.MAX_VALUE,
             {
-                from: rewardNodeHolder
+                from: increasedPrizePayoutNodeHolder
             }
         )
         // Create node of type ID 2
         await dbetNode.create(
             2,
             {
-                from: rewardNodeHolder
+                from: increasedPrizePayoutNodeHolder
             }
         )
         // Move forward in time by `timeThreshold` to activate node
@@ -932,16 +932,16 @@ contract('Quest', accounts => {
 
         const nodeId = 2
 
-        const prePayForQuestBalance = await token.balanceOf(rewardNodeHolder)
+        const prePayForQuestBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         await quest.payForQuestWithNode(
             id,
             nodeId,
-            rewardNodeHolder,
+            increasedPrizePayoutNodeHolder,
             {
-                from: rewardNodeHolder
+                from: increasedPrizePayoutNodeHolder
             }
         )
-        const postPayForQuestBalance = await token.balanceOf(rewardNodeHolder)
+        const postPayForQuestBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         assert.equal(
             new BigNumber(postPayForQuestBalance).isEqualTo(
                 new BigNumber(prePayForQuestBalance).minus(
@@ -951,7 +951,7 @@ contract('Quest', accounts => {
             true
         )
         const userQuestEntryFee = (await quest.userQuestEntries(
-            rewardNodeHolder,
+            increasedPrizePayoutNodeHolder,
             id,
             0
         )).entryFee
@@ -972,13 +972,13 @@ contract('Quest', accounts => {
             increasedPrizePayout
         } = getIncreasedPrizePayoutNode()
 
-        const preSetQuestOutcomeBalance = await token.balanceOf(rewardNodeHolder)
+        const preSetQuestOutcomeBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         await quest.setQuestOutcome(
             id,
-            rewardNodeHolder,
+            increasedPrizePayoutNodeHolder,
             OUTCOME_SUCCESS
         )
-        const postSetQuestOutcomeBalance = await token.balanceOf(rewardNodeHolder)
+        const postSetQuestOutcomeBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
 
         assert.equal(
             new BigNumber(
@@ -1009,16 +1009,16 @@ contract('Quest', accounts => {
 
         // Enter quest again
         const nodeId = 2
-        const prePayForQuestBalance = await token.balanceOf(rewardNodeHolder)
+        const prePayForQuestBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         await quest.payForQuestWithNode(
             id,
             nodeId,
-            rewardNodeHolder,
+            increasedPrizePayoutNodeHolder,
             {
-                from: rewardNodeHolder
+                from: increasedPrizePayoutNodeHolder
             }
         )
-        const postPayForQuestBalance = await token.balanceOf(rewardNodeHolder)
+        const postPayForQuestBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         assert.equal(
             new BigNumber(postPayForQuestBalance).isEqualTo(
                 new BigNumber(prePayForQuestBalance).minus(
@@ -1028,12 +1028,12 @@ contract('Quest', accounts => {
             true
         )
 
-        const preCancelQuestEntryBalance = await token.balanceOf(rewardNodeHolder)
+        const preCancelQuestEntryBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         await quest.cancelQuestEntry(
             id,
-            rewardNodeHolder
+            increasedPrizePayoutNodeHolder
         )
-        const postCancelQuestEntryBalance = await token.balanceOf(rewardNodeHolder)
+        const postCancelQuestEntryBalance = await token.balanceOf(increasedPrizePayoutNodeHolder)
         assert.equal(
             new BigNumber(postCancelQuestEntryBalance).isEqualTo(
                 new BigNumber(preCancelQuestEntryBalance).plus(

--- a/test/Quest.js
+++ b/test/Quest.js
@@ -5,7 +5,8 @@ const Web3 = require('web3')
 const contracts = require('./utils/contracts')
 const utils = require('./utils/utils')
 const {
-    getNode,
+    getHouseNode,
+    getIncreasedPrizePayoutNode,
     getValidNodeQuestParams
 } = require('./utils/nodes')
 
@@ -687,7 +688,7 @@ contract('Quest', accounts => {
             rewards,
             entryFeeDiscount,
             increasedPrizePayout
-        } = getNode()
+        } = getHouseNode()
         await dbetNode.addNode(
             name,
             tokenThreshold,
@@ -713,9 +714,9 @@ contract('Quest', accounts => {
                 from: nodeHolder
             }
         )
-        // Create node of type ID 0
+        // Create node of type ID 1
         await dbetNode.create(
-            0,
+            1,
             {
                 from: nodeHolder
             }
@@ -728,9 +729,10 @@ contract('Quest', accounts => {
             maxEntries
         } = getValidNodeQuestParams()
 
+        const nodeId = 1
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 id,
                 entryFee,
                 prize,
@@ -751,9 +753,10 @@ contract('Quest', accounts => {
             maxEntries
         } = getValidNodeQuestParams()
 
+        const nodeId = 1
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 id,
                 entryFee,
                 prize,
@@ -765,7 +768,7 @@ contract('Quest', accounts => {
     it('throws if active node holders add node quests with invalid parameters', async () => {
         const {
             timeThreshold,
-        } = getNode()
+        } = getHouseNode()
         // Move forward in time by `timeThreshold` to activate node
         await timeTravel(timeThreshold)
 
@@ -778,9 +781,10 @@ contract('Quest', accounts => {
         } = getValidNodeQuestParams()
 
         // Invalid id - existing quest ID
+        const nodeId = 1
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 web3.utils.fromUtf8('123'),
                 entryFee,
                 prize,
@@ -794,7 +798,7 @@ contract('Quest', accounts => {
         // Invalid entry fee - 0
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 id,
                 0,
                 prize,
@@ -808,7 +812,7 @@ contract('Quest', accounts => {
         // Invalid prize - 0
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 id,
                 entryFee,
                 0,
@@ -822,7 +826,7 @@ contract('Quest', accounts => {
         // Invalid max entries - 0
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 id,
                 entryFee,
                 prize,
@@ -843,9 +847,10 @@ contract('Quest', accounts => {
             maxEntries
         } = getValidNodeQuestParams()
 
+        const nodeId = 1
         // Add node quest
         await quest.addNodeQuest(
-            1,
+            nodeId,
             id,
             entryFee,
             prize,
@@ -870,7 +875,7 @@ contract('Quest', accounts => {
         } = getValidNodeQuestParams()
         const {
             entryFeeDiscount
-        } = getNode()
+        } = getHouseNode()
         const nodeId = 1
 
         const prePayForQuestBalance = await token.balanceOf(nodeHolder)
@@ -911,7 +916,7 @@ contract('Quest', accounts => {
         } = getValidNodeQuestParams()
         const {
             increasedPrizePayout
-        } = getNode()
+        } = getHouseNode()
 
         const preSetQuestOutcomeBalance = await token.balanceOf(nodeHolder)
         await quest.setQuestOutcome(
@@ -946,7 +951,7 @@ contract('Quest', accounts => {
         } = getValidNodeQuestParams()
         const {
             entryFeeDiscount
-        } = getNode()
+        } = getHouseNode()
 
         // Enter quest again
         const nodeId = 1
@@ -989,7 +994,7 @@ contract('Quest', accounts => {
         const {
             id
         } = getValidNodeQuestParams()
-        const nodeId = 0
+        const nodeId = 1
         await utils.assertFail(
             quest.cancelNodeQuest(
                 nodeId,
@@ -1003,7 +1008,7 @@ contract('Quest', accounts => {
 
     it('throws if active node holders cancel invalid quest IDs', async () => {
         const invalidId = web3.utils.fromUtf8('789')
-        const nodeId = 0
+        const nodeId = 1
         await utils.assertFail(
             quest.cancelNodeQuest(
                 nodeId,
@@ -1083,7 +1088,7 @@ contract('Quest', accounts => {
         // Check if node holder received locked deposit
         const {
             tokenThreshold
-        } = getNode()
+        } = getHouseNode()
         assert.equal(
             new BigNumber(postDestroyBalance).minus(preDestroyBalance).isEqualTo(tokenThreshold),
             true
@@ -1092,7 +1097,7 @@ contract('Quest', accounts => {
         // Try adding quest using an inactive node
         await utils.assertFail(
             quest.addNodeQuest(
-                0,
+                nodeId,
                 web3.utils.fromUtf8('222'),
                 entryFee,
                 prize,

--- a/test/Tournament.js
+++ b/test/Tournament.js
@@ -1152,7 +1152,8 @@ contract('Tournament', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         } = getHouseNode()
         await dbetNode.addNode(
             name,
@@ -1161,7 +1162,8 @@ contract('Tournament', accounts => {
             maxCount,
             rewards,
             entryFeeDiscount,
-            increasedPrizePayout
+            increasedPrizePayout,
+            nodeType
         )
 
         // Approve tokens to be transferred on behalf of user from DBETNode and Quest contracts

--- a/test/Tournament.js
+++ b/test/Tournament.js
@@ -15,7 +15,7 @@ const {
 } = require('./utils/tournament')
 
 const {
-    getNode
+    getHouseNode
 } = require('./utils/nodes')
 
 let admin,
@@ -1153,7 +1153,7 @@ contract('Tournament', accounts => {
             rewards,
             entryFeeDiscount,
             increasedPrizePayout
-        } = getNode()
+        } = getHouseNode()
         await dbetNode.addNode(
             name,
             tokenThreshold,
@@ -1179,9 +1179,9 @@ contract('Tournament', accounts => {
                 from: nodeHolder
             }
         )
-        // Create node of type ID 0
+        // Create node of type ID 1
         await dbetNode.create(
-            0,
+            1,
             {
                 from: nodeHolder
             }
@@ -1217,7 +1217,7 @@ contract('Tournament', accounts => {
     it('throws if active node holders create node tournaments with invalid parameters', async () => {
         const {
             timeThreshold,
-        } = getNode()
+        } = getHouseNode()
         // Move forward in time by `timeThreshold` to activate node
         await timeTravel(timeThreshold)
 
@@ -1408,7 +1408,7 @@ contract('Tournament', accounts => {
         } = getValidTournamentParams(1)
         const {
             entryFeeDiscount
-        } = getNode()
+        } = getHouseNode()
 
         const nodeId = 1
         const preEnterTournamentUserBalance =
@@ -1569,7 +1569,7 @@ contract('Tournament', accounts => {
 
         const {
             entryFeeDiscount
-        } = getNode()
+        } = getHouseNode()
 
         // Complete tournament with `FAILED` status
         await tournament.completeTournament(

--- a/test/utils/nodes.js
+++ b/test/utils/nodes.js
@@ -5,6 +5,9 @@ const REWARD_CREATE_PRIVATE_QUEST = 3
 const REWARD_CREATE_WHITELIST_QUEST = 4
 const REWARD_CREATE_TOURNAMENT = 5
 
+const NODE_TYPE_HOUSE = 0
+const NODE_TYPE_REWARD = 1
+
 const houseRewards = [
     REWARD_CREATE_QUEST,
     REWARD_CREATE_PRIVATE_QUEST,
@@ -30,7 +33,8 @@ const getHouseNode = () => {
         maxCount: 10,
         rewards: houseRewards,
         entryFeeDiscount: 10,
-        increasedPrizePayout: 10
+        increasedPrizePayout: 10,
+        nodeType: NODE_TYPE_HOUSE
     }
 }
 
@@ -42,7 +46,8 @@ const getIncreasedPrizePayoutNode = () => {
         maxCount: 10,
         rewards: increasedPrizePayoutRewards,
         entryFeeDiscount: 10,
-        increasedPrizePayout: 10
+        increasedPrizePayout: 10,
+        nodeType: NODE_TYPE_REWARD
     }
 }
 
@@ -54,7 +59,8 @@ const getUpgradedNode = () => {
         maxCount: 5,
         rewards: allRewards,
         entryFeeDiscount: 25,
-        increasedPrizePayout: 25
+        increasedPrizePayout: 25,
+        nodeType: NODE_TYPE_HOUSE
     }
 }
 

--- a/test/utils/nodes.js
+++ b/test/utils/nodes.js
@@ -5,22 +5,42 @@ const REWARD_CREATE_PRIVATE_QUEST = 3
 const REWARD_CREATE_WHITELIST_QUEST = 4
 const REWARD_CREATE_TOURNAMENT = 5
 
-const rewards = [
-    REWARD_INCREASED_PRIZE_PAYOUTS,
-    REWARD_INCREASED_REFER_A_FRIEND,
+const houseRewards = [
     REWARD_CREATE_QUEST,
     REWARD_CREATE_PRIVATE_QUEST,
     REWARD_CREATE_WHITELIST_QUEST,
     REWARD_CREATE_TOURNAMENT
 ]
 
-const getNode = () => {
+const increasedPrizePayoutRewards = [
+    REWARD_INCREASED_PRIZE_PAYOUTS,
+    REWARD_INCREASED_REFER_A_FRIEND
+]
+
+const allRewards = [
+    ...houseRewards,
+    ...increasedPrizePayoutRewards
+]
+
+const getHouseNode = () => {
     return {
         name: 'House',
         tokenThreshold: web3.utils.toWei('100000', 'ether'), // 100k DBETs
         timeThreshold: 86400 * 7, // 1 week
         maxCount: 10,
-        rewards,
+        rewards: houseRewards,
+        entryFeeDiscount: 10,
+        increasedPrizePayout: 10
+    }
+}
+
+const getIncreasedPrizePayoutNode = () => {
+    return {
+        name: 'Reward',
+        tokenThreshold: web3.utils.toWei('100000', 'ether'), // 100k DBETs
+        timeThreshold: 86400 * 7, // 1 week
+        maxCount: 10,
+        rewards: increasedPrizePayoutRewards,
         entryFeeDiscount: 10,
         increasedPrizePayout: 10
     }
@@ -28,11 +48,11 @@ const getNode = () => {
 
 const getUpgradedNode = () => {
     return {
-        name: 'House Tier II',
+        name: 'Upgraded',
         tokenThreshold: web3.utils.toWei('200000', 'ether'), // 100k DBETs
         timeThreshold: 86400 * 14, // 2 weeks
         maxCount: 5,
-        rewards,
+        rewards: allRewards,
         entryFeeDiscount: 25,
         increasedPrizePayout: 25
     }
@@ -59,8 +79,10 @@ module.exports = {
     REWARD_CREATE_PRIVATE_QUEST,
     REWARD_CREATE_WHITELIST_QUEST,
     REWARD_CREATE_TOURNAMENT,
-    rewards,
-    getNode,
+    houseRewards,
+    increasedPrizePayoutRewards,
+    getHouseNode,
+    getIncreasedPrizePayoutNode,
     getUpgradedNode,
     getValidNodeQuestParams
 }


### PR DESCRIPTION
* Limit node ownership to single nodes per address
* Split `isActiveNode()` in Quest contract to `isActiveHouseNode()` and `isActiveIncreasedPrizePayoutNode()`
* Check if user node satisfies `isActiveIncreasedPrizePayoutNode()` for node discounts
* Add `nodeType` prop to `addNode()` and `Node` struct
* Add `deprecated` prop to `Node` struct, add `deprecateNode()`
* Add/update tests