### PR TITLE
Restrict non-quest payers from receiving increased prize payouts, add indexed params to events

### DIFF
--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -37,13 +37,15 @@ LibQuest {
     );
     // On cancel quest
     event LogCancelQuest(
-        bytes32 indexed id
+        bytes32 indexed id,
+        address indexed canceller
     );
     // On cancel quest entry
     event LogCancelQuestEntry(
         bytes32 indexed id,
         address indexed user,
-        uint256 questEntryCount
+        uint256 questEntryCount,
+        address indexed canceller
     );
     // On pay for quest
     event LogPayForQuest(
@@ -461,15 +463,8 @@ LibQuest {
     returns (bool) {
         // Allow only admins to cancel quests
         require(admin.admins(msg.sender), "INVALID_SENDER_ADMIN_STATUS");
-        // Quest must be active
-        require(quests[id].status == uint8(QuestStatus.ACTIVE), "INVALID_QUEST_STATUS");
-        // Cancel quest
-        quests[id].status = uint8(QuestStatus.CANCELLED);
-        // Emit cancel quest event
-        emit LogCancelQuest(
-            id
-        );
-        return true;
+        // Complete quest cancellation
+        return _completeCancelQuest(id);
     }
 
     /**
@@ -499,13 +494,23 @@ LibQuest {
             quests[id].nodeId == nodeId,
             "INVALID_QUEST_NODE_OWNERSHIP"
         );
+        // Complete quest cancellation
+        return _completeCancelQuest(id);
+    }
+
+    function _completeCancelQuest(
+        bytes32 id
+    )
+    internal
+    returns (bool) {
         // Quest must be active
         require(quests[id].status == uint8(QuestStatus.ACTIVE), "INVALID_QUEST_STATUS");
         // Cancel quest
         quests[id].status = uint8(QuestStatus.CANCELLED);
         // Emit cancel quest event
         emit LogCancelQuest(
-            id
+            id,
+            msg.sender
         );
         return true;
     }
@@ -543,7 +548,8 @@ LibQuest {
         emit LogCancelQuestEntry(
             id,
             user,
-            _userQuestEntryCount
+            _userQuestEntryCount,
+            msg.sender
         );
         return true;
     }

--- a/contracts/quest/Quest.sol
+++ b/contracts/quest/Quest.sol
@@ -307,7 +307,8 @@ LibQuest {
             entryFee: entryFee,
             nodeId: nodeId,
             status: uint8(QuestEntryStatus.STARTED),
-            refunded: false
+            refunded: false,
+            payer: msg.sender
         });
         // Increment quest count
         quests[id].count++;
@@ -399,8 +400,11 @@ LibQuest {
             (uint256 node,,,,,) = dbetNode.userNodes(
                 userQuestEntries[user][id][_userQuestEntryCount].nodeId
             );
-            // Prize must not account for increased prize payout if quest is a node quest
-            uint256 prize = quests[id].isNode ?
+            // Check if `user` paid for the quest
+            bool isUserPayer = userQuestEntries[user][id][_userQuestEntryCount].payer == user;
+            // Prize must not account for increased prize payout if quest is a node quest OR
+            // If the user didn't pay for the quest
+            uint256 prize = quests[id].isNode || !isUserPayer ?
                 quests[id].prize :
                 getPrizePayoutForNodeType(
                     node,

--- a/contracts/quest/libs/LibQuest.sol
+++ b/contracts/quest/libs/LibQuest.sol
@@ -46,6 +46,8 @@ contract LibQuest {
         uint256 nodeId;
         // True if user claims refund for a cancelled quest
         bool refunded;
+        // Address that paid for the user quest entry
+        address payer;
     }
 
 }

--- a/test/Quest.js
+++ b/test/Quest.js
@@ -1049,6 +1049,54 @@ contract('Quest', accounts => {
         )
     })
 
+    it('pays regular prize payout if node holder wins non-node quest when payer is not node holder', async () => {
+        const {
+            id,
+            entryFee,
+            prize
+        } = getValidSecondQuestParams()
+
+        // Pay for quest with sufficient allowance and balance
+        const prePayForQuestBalance = await token.balanceOf(owner)
+        await quest.payForQuest(
+            id,
+            rewardNodeHolder
+        )
+        const postPayForQuestBalance = await token.balanceOf(owner)
+        assert.equal(
+            new BigNumber(postPayForQuestBalance).isEqualTo(
+                new BigNumber(prePayForQuestBalance).minus(
+                    new BigNumber(entryFee)
+                )
+            ),
+            true
+        )
+
+        // Set quest outcome to `SUCCESS`
+        const preSetQuestOutcomeBalance = await token.balanceOf(rewardNodeHolder)
+        await quest.setQuestOutcome(
+            id,
+            rewardNodeHolder,
+            OUTCOME_SUCCESS
+        )
+        const postSetQuestOutcomeBalance = await token.balanceOf(rewardNodeHolder)
+
+        assert.equal(
+            new BigNumber(
+                postSetQuestOutcomeBalance
+            ).isEqualTo(
+                new BigNumber(
+                    preSetQuestOutcomeBalance
+                ).plus(
+                    new BigNumber(
+                        prize
+                    )
+                )
+            ),
+            true
+        )
+    })
+
     it('pays regular prize payout if node holder wins node quest', async () => {
         const {
             id,


### PR DESCRIPTION
* Add `payer` prop to UserQuestEntry struct
* Check if `payer` is `user` in `setQuestOutcome()` and account for `increasedPrizePayout` if true
* Add indexed params to events
* Unify function logic and reduce deployed bytecode size
* Update tests